### PR TITLE
Update to syn=2 and fletcher=1

### DIFF
--- a/easy_hash/Cargo.toml
+++ b/easy_hash/Cargo.toml
@@ -14,7 +14,7 @@ default = ["nalgebra", "ordered_float", "rapier"]
 
 [dependencies]
 easy_hash_derive = { path = "../easy_hash_derive" }
-fletcher = "0.3.0"
+fletcher = "1.0"
 bytemuck = "1.22.0"
 const-fnv1a-hash = "1.1.0"
 bevy_ecs = { version = "0.14", optional = true }

--- a/easy_hash_derive/Cargo.toml
+++ b/easy_hash_derive/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.105", features = ["full", "extra-traits"] }
+syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1.0.21"
 proc-macro2 = "1.0.47"

--- a/easy_hash_derive/src/lib.rs
+++ b/easy_hash_derive/src/lib.rs
@@ -113,7 +113,7 @@ fn hash_sum(data: &Data) -> TokenStream {
                                 let ignore = f
                                     .attrs
                                     .iter()
-                                    .any(|attr| attr.path.is_ident("easy_hash_ignore"));
+                                    .any(|attr| attr.path().is_ident("easy_hash_ignore"));
                                 !ignore
                             })
                             .map(|f| {
@@ -183,7 +183,7 @@ fn hash_sum(data: &Data) -> TokenStream {
                             let ignore = f
                                 .attrs
                                 .iter()
-                                .any(|attr| attr.path.is_ident("easy_hash_ignore"));
+                                .any(|attr| attr.path().is_ident("easy_hash_ignore"));
                             !ignore
                         })
                         .map(|f| {


### PR DESCRIPTION
## Summary
- bump `syn` dependency to 2.0
- bump `fletcher` to 1.0
- update derive crate code for new `syn` API

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683f692a9518832395bfcd7e819fa50b