### PR TITLE
Update to Rust 2024 edition

### DIFF
--- a/easy_hash/Cargo.toml
+++ b/easy_hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "easy_hash"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/easy_hash_derive/Cargo.toml
+++ b/easy_hash_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "easy_hash_derive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/easy_hash_derive/src/lib.rs
+++ b/easy_hash_derive/src/lib.rs
@@ -96,7 +96,7 @@ fn hash_sum(data: &Data) -> TokenStream {
                             }
                         }
                     }
-                    Fields::Named(ref fields) => {
+                    Fields::Named(fields) => {
                         // this expands to eg:
                         // ```
                         // Self::C { x, y } => {


### PR DESCRIPTION
## Summary
- switch crates to Rust 2024 edition
- apply edition migration fixups

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6840fb3d04088323b0c10897176e3b86