### PR TITLE
Improve hashing performance

### DIFF
--- a/easy_hash/src/lib.rs
+++ b/easy_hash/src/lib.rs
@@ -37,18 +37,22 @@ pub const fn type_salt<T>() -> u32 {
     fnv1a_hash_str_32(std::any::type_name::<T>())
 }
 
+#[inline]
 pub fn split_u64(x: u64) -> [u32; 2] {
     [(x >> 32) as u32, x as u32]
 }
 
+#[inline]
 pub fn u64_to_u32_slice(x: &[u64]) -> &[u32] {
     bytemuck::cast_slice(x)
 }
 
+#[inline]
 pub fn join_u32s(a: u32, b: u32) -> u64 {
     ((a as u64) << 32) | (b as u64)
 }
 
+#[inline]
 pub fn split_i64(x: i64) -> [u32; 2] {
     [(x >> 32) as u32, x as u32]
 }
@@ -71,17 +75,14 @@ where
     const TYPE_SALT: u32 = type_salt::<T>();
 
     fn ehash(&self) -> u64 {
-        let mut checksum = fletcher::Fletcher64::new();
-        checksum.update(&[Self::TYPE_SALT]);
+        const NONE_VAL: u32 = 780526312;
 
         if let Some(x) = self {
-            checksum.update(&split_u64(x.ehash()));
+            let parts = split_u64(x.ehash());
+            calc_fletcher64(&[Self::TYPE_SALT, parts[0], parts[1]])
         } else {
-            let none_val: u32 = 780526312;
-            checksum.update(&[none_val]);
+            calc_fletcher64(&[Self::TYPE_SALT, NONE_VAL])
         }
-
-        checksum.value()
     }
 }
 
@@ -94,9 +95,8 @@ where
     fn ehash(&self) -> u64 {
         let mut checksum = fletcher::Fletcher64::new();
         checksum.update(&[Self::TYPE_SALT]);
-        for x in self {
-            checksum.update(&split_u64(x.ehash()));
-        }
+        let hashes: Vec<u64> = self.iter().map(|x| x.ehash()).collect();
+        checksum.update(u64_to_u32_slice(&hashes));
         checksum.value()
     }
 }
@@ -106,11 +106,14 @@ impl EasyHash for &str {
     fn ehash(&self) -> u64 {
         let mut checksum = fletcher::Fletcher64::new();
         checksum.update(&[Self::TYPE_SALT]);
-        for chunk in self.as_bytes().rchunks(4) {
+        let bytes = self.as_bytes();
+        let (chunks, remainder) = bytes.as_chunks::<4>();
+        for chunk in chunks {
+            checksum.update(&[u32::from_le_bytes(*chunk)]);
+        }
+        if !remainder.is_empty() {
             let mut byte = [0u8; 4];
-            for j in 0..4 {
-                byte[j] = *chunk.get(j).unwrap_or(&0);
-            }
+            byte[..remainder.len()].copy_from_slice(remainder);
             checksum.update(&[u32::from_le_bytes(byte)]);
         }
         checksum.value()
@@ -123,11 +126,14 @@ impl EasyHash for String {
         let mut checksum = fletcher::Fletcher64::new();
         checksum.update(&[Self::TYPE_SALT]);
 
-        for chunk in self.as_bytes().rchunks(4) {
+        let bytes = self.as_bytes();
+        let (chunks, remainder) = bytes.as_chunks::<4>();
+        for chunk in chunks {
+            checksum.update(&[u32::from_le_bytes(*chunk)]);
+        }
+        if !remainder.is_empty() {
             let mut byte = [0u8; 4];
-            for j in 0..4 {
-                byte[j] = *chunk.get(j).unwrap_or(&0);
-            }
+            byte[..remainder.len()].copy_from_slice(remainder);
             checksum.update(&[u32::from_le_bytes(byte)]);
         }
         checksum.value()

--- a/easy_hash/tests/test_option.rs
+++ b/easy_hash/tests/test_option.rs
@@ -1,0 +1,19 @@
+use easy_hash::EasyHash;
+
+#[test]
+fn test_option_some_vs_none() {
+    let some = Some(42u32);
+    let none: Option<u32> = None;
+    assert_ne!(some.ehash(), none.ehash());
+}
+
+#[test]
+fn test_option_equality() {
+    let a: Option<u64> = Some(5);
+    let b: Option<u64> = Some(5);
+    let c: Option<u64> = None;
+    let d: Option<u64> = None;
+    assert_eq!(a.ehash(), b.ehash());
+    assert_eq!(c.ehash(), d.ehash());
+    assert_ne!(a.ehash(), c.ehash());
+}

--- a/easy_hash_derive/src/lib.rs
+++ b/easy_hash_derive/src/lib.rs
@@ -86,7 +86,7 @@ fn hash_sum(data: &Data) -> TokenStream {
                         });
 
                         let hash_expr = quote! {
-                            #(#field_hash_exprs.ehash(),)*
+                            #(#field_hash_exprs,)*
                         };
 
                         quote! {


### PR DESCRIPTION
## Summary
- remove redundant hashing in enum derive macro
- use chunk-based loops for `&str` and `String`
- optimize hashing for `Option<T>` and `OnceCell<T>`
- inline helper utility functions
- bulk hash `Vec<T>` values
- add option hashing tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68410339b9e48323b968e80e29052937