### PR TITLE
Update to Rust 2024 edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ The attribute `easy_hash_ignore` skips a field when computing the hash.
 
 ## Building
 
-This workspace requires the nightly toolchain and uses Cargo to run the
+This workspace targets the **Rust 2024 edition** and currently requires a
+nightly toolchain (1.78 or newer) to build the crates. Use Cargo to run the
 tests:
 
 ```bash

--- a/easy_hash/Cargo.toml
+++ b/easy_hash/Cargo.toml
@@ -2,6 +2,7 @@
 name = "easy_hash"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/easy_hash_derive/Cargo.toml
+++ b/easy_hash_derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "easy_hash_derive"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Summary
- document the Rust 2024 edition requirement
- record the `rust-version` (1.85) for each crate

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6849d8fbf93c8323a8a3d57bbdaa51e4