### PR TITLE
Increase test coverage to 100% with targeted tests for primitives, bytemuck, godot and derive macro

### DIFF
--- a/easy_hash/src/type_id.rs
+++ b/easy_hash/src/type_id.rs
@@ -36,3 +36,18 @@ impl EasyHash for TypeId {
         hasher.finish()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::IdentityHasher;
+    use std::hash::Hasher;
+
+    #[test]
+    #[should_panic(
+        expected = "IdentityHasher does not support writing bytes directly. Use write_u64 instead."
+    )]
+    fn identity_hasher_write_panics() {
+        let mut hasher = IdentityHasher(0);
+        hasher.write(b"unsupported");
+    }
+}

--- a/easy_hash/tests/test_bytemuck_alignment.rs
+++ b/easy_hash/tests/test_bytemuck_alignment.rs
@@ -1,0 +1,45 @@
+use bytemuck::pod_align_to;
+use easy_hash::fletcher::Fletcher64;
+use easy_hash::{EasyHash, type_salt};
+
+fn hash_with_alignment<T: bytemuck::Pod>(data: &[T], type_salt: u32) -> u64 {
+    let mut checksum = Fletcher64::new();
+    checksum.update(&[type_salt]);
+
+    let (head, body_u32, tail) = pod_align_to::<T, u32>(data);
+
+    if !head.is_empty() {
+        let bytes = bytemuck::cast_slice::<T, u8>(head);
+        let mut buf = [0u8; 4];
+        buf[..bytes.len()].copy_from_slice(bytes);
+        checksum.update(&[u32::from_le_bytes(buf)]);
+    }
+
+    checksum.update(body_u32);
+
+    if !tail.is_empty() {
+        let bytes = bytemuck::cast_slice::<T, u8>(tail);
+        let mut buf = [0u8; 4];
+        buf[..bytes.len()].copy_from_slice(bytes);
+        checksum.update(&[u32::from_le_bytes(buf)]);
+    }
+
+    checksum.value()
+}
+
+#[test]
+fn test_u8_slice_unaligned_head_and_tail() {
+    let data = [0x11u8, 0x22, 0x33, 0x44, 0x55];
+    let slice = &data[1..];
+    let expected = hash_with_alignment(slice, type_salt::<&[u8]>());
+
+    assert_eq!(slice.ehash(), expected);
+}
+
+#[test]
+fn test_u8_array_tail_padding() {
+    let data = [0x10u8, 0x20, 0x30];
+    let expected = hash_with_alignment(&data, type_salt::<[u8; 3]>());
+
+    assert_eq!(data.ehash(), expected);
+}

--- a/easy_hash/tests/test_godot.rs
+++ b/easy_hash/tests/test_godot.rs
@@ -1,0 +1,49 @@
+use easy_hash::fletcher::Fletcher64;
+use easy_hash::{EasyHash, type_salt};
+use godot::builtin::{Vector2, Vector2i, Vector3, Vector3i};
+
+#[test]
+fn test_vector2_hash_matches_manual() {
+    let value = Vector2::new(1.25, -2.5);
+    let mut checksum = Fletcher64::new();
+    checksum.update(&[type_salt::<Vector2>(), value.x.to_bits(), value.y.to_bits()]);
+
+    assert_eq!(value.ehash(), checksum.value());
+}
+
+#[test]
+fn test_vector3_hash_matches_manual() {
+    let value = Vector3::new(1.25, -2.5, 3.75);
+    let mut checksum = Fletcher64::new();
+    checksum.update(&[
+        type_salt::<Vector3>(),
+        value.x.to_bits(),
+        value.y.to_bits(),
+        value.z.to_bits(),
+    ]);
+
+    assert_eq!(value.ehash(), checksum.value());
+}
+
+#[test]
+fn test_vector2i_hash_matches_manual() {
+    let value = Vector2i::new(7, -11);
+    let mut checksum = Fletcher64::new();
+    checksum.update(&[type_salt::<Vector2i>(), value.x as u32, value.y as u32]);
+
+    assert_eq!(value.ehash(), checksum.value());
+}
+
+#[test]
+fn test_vector3i_hash_matches_manual() {
+    let value = Vector3i::new(7, -11, 42);
+    let mut checksum = Fletcher64::new();
+    checksum.update(&[
+        type_salt::<Vector3i>(),
+        value.x as u32,
+        value.y as u32,
+        value.z as u32,
+    ]);
+
+    assert_eq!(value.ehash(), checksum.value());
+}

--- a/easy_hash/tests/test_primitives_branches.rs
+++ b/easy_hash/tests/test_primitives_branches.rs
@@ -1,0 +1,151 @@
+use easy_hash::fletcher::calc_fletcher64;
+use easy_hash::{EasyHash, split_u64, type_salt};
+use proptest::prelude::*;
+use test_case::test_case;
+
+#[test]
+fn test_u8_max_branch() {
+    let value = u8::MAX;
+    let expected = calc_fletcher64(&[type_salt::<u8>(), (value as u32) | type_salt::<u8>()]);
+
+    assert_eq!(value.ehash(), expected);
+}
+
+#[test]
+fn test_u16_max_branch() {
+    let value = u16::MAX;
+    let expected = calc_fletcher64(&[type_salt::<u16>(), (value as u32) | type_salt::<u16>()]);
+
+    assert_eq!(value.ehash(), expected);
+}
+
+#[test]
+fn test_u32_max_branch() {
+    let value = u32::MAX;
+    let expected = calc_fletcher64(&[type_salt::<u32>(), value, type_salt::<u32>()]);
+
+    assert_eq!(value.ehash(), expected);
+}
+
+#[test]
+fn test_u64_max_branch() {
+    let value = u64::MAX;
+    let mut checksum = easy_hash::fletcher::Fletcher64::new();
+    checksum.update(&[type_salt::<u64>()]);
+    checksum.update(&split_u64(value));
+    checksum.update(&[type_salt::<u64>()]);
+
+    assert_eq!(value.ehash(), checksum.value());
+}
+
+#[test]
+fn test_i8_negative_one_branch() {
+    let value = -1i8;
+    let expected = calc_fletcher64(&[type_salt::<i8>(), (value as u32) | type_salt::<i8>()]);
+
+    assert_eq!(value.ehash(), expected);
+}
+
+#[test_case(0i8; "zero")]
+#[test_case(42i8; "positive")]
+fn test_i8_non_max_values(value: i8) {
+    let expected = calc_fletcher64(&[type_salt::<i8>(), value as u32]);
+
+    assert_eq!(value.ehash(), expected);
+}
+
+#[test]
+fn test_i16_negative_one_branch() {
+    let value = -1i16;
+    let expected = calc_fletcher64(&[type_salt::<i16>(), (value as u32) | type_salt::<i16>()]);
+
+    assert_eq!(value.ehash(), expected);
+}
+
+#[test_case(0i16; "zero")]
+#[test_case(1234i16; "positive")]
+fn test_i16_non_max_values(value: i16) {
+    let expected = calc_fletcher64(&[type_salt::<i16>(), value as u32]);
+
+    assert_eq!(value.ehash(), expected);
+}
+
+#[test]
+fn test_i32_negative_one_branch() {
+    let value = -1i32;
+    let expected = calc_fletcher64(&[type_salt::<i32>(), value as u32, type_salt::<i32>()]);
+
+    assert_eq!(value.ehash(), expected);
+}
+
+#[test]
+fn test_i64_negative_one_branch() {
+    let value = -1i64;
+    let mut checksum = easy_hash::fletcher::Fletcher64::new();
+    checksum.update(&[type_salt::<i64>()]);
+    checksum.update(&split_u64(value as u64));
+    checksum.update(&[type_salt::<i64>()]);
+
+    assert_eq!(value.ehash(), checksum.value());
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn test_usize_max_branch() {
+    let value = usize::MAX;
+    let mut checksum = easy_hash::fletcher::Fletcher64::new();
+    checksum.update(&[type_salt::<usize>()]);
+    checksum.update(&split_u64(value as u64));
+    checksum.update(&[type_salt::<usize>()]);
+
+    assert_eq!(value.ehash(), checksum.value());
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn test_isize_negative_one_branch() {
+    let value = -1isize;
+    let mut checksum = easy_hash::fletcher::Fletcher64::new();
+    checksum.update(&[type_salt::<isize>()]);
+    checksum.update(&split_u64(value as u64));
+    checksum.update(&[type_salt::<isize>()]);
+
+    assert_eq!(value.ehash(), checksum.value());
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test_case(0isize; "zero")]
+#[test_case(42isize; "positive")]
+fn test_isize_non_max_values(value: isize) {
+    let mut checksum = easy_hash::fletcher::Fletcher64::new();
+    checksum.update(&[type_salt::<isize>()]);
+    checksum.update(&split_u64(value as u64));
+
+    assert_eq!(value.ehash(), checksum.value());
+}
+
+proptest! {
+    #[test]
+    fn prop_u64_hash_matches_manual(value in prop_oneof![Just(u64::MAX), any::<u64>()]) {
+        let mut checksum = easy_hash::fletcher::Fletcher64::new();
+        checksum.update(&[type_salt::<u64>()]);
+        checksum.update(&split_u64(value));
+        if value == u64::MAX {
+            checksum.update(&[type_salt::<u64>()]);
+        }
+
+        prop_assert_eq!(value.ehash(), checksum.value());
+    }
+
+    #[test]
+    fn prop_i64_hash_matches_manual(value in prop_oneof![Just(-1i64), any::<i64>()]) {
+        let mut checksum = easy_hash::fletcher::Fletcher64::new();
+        checksum.update(&[type_salt::<i64>()]);
+        checksum.update(&split_u64(value as u64));
+        if value as u64 == u64::MAX {
+            checksum.update(&[type_salt::<i64>()]);
+        }
+
+        prop_assert_eq!(value.ehash(), checksum.value());
+    }
+}

--- a/easy_hash/tests/test_strings.rs
+++ b/easy_hash/tests/test_strings.rs
@@ -51,6 +51,14 @@ fn test_str_vs_string() {
 }
 
 #[test]
+fn test_str_exact_chunks() {
+    let s_str = "test";
+    let s_string = String::from("test");
+
+    assert_ne!(s_str.ehash(), s_string.ehash());
+}
+
+#[test]
 fn test_str_slices() {
     let s = "hello world";
     let slice1 = &s[0..5];

--- a/easy_hash/tests/test_type_salt_generic.rs
+++ b/easy_hash/tests/test_type_salt_generic.rs
@@ -1,0 +1,19 @@
+use easy_hash::type_salt_generic;
+
+#[test]
+fn test_type_salt_generic_deterministic() {
+    let first = type_salt_generic::<Option<u8>, u16>();
+    let second = type_salt_generic::<Option<u8>, u16>();
+
+    assert_eq!(first, second);
+}
+
+#[test]
+fn test_type_salt_generic_differs_for_generic() {
+    let baseline = type_salt_generic::<Option<u8>, u16>();
+    let different_generic = type_salt_generic::<Option<u8>, u32>();
+    let swapped = type_salt_generic::<u16, Option<u8>>();
+
+    assert_ne!(baseline, different_generic);
+    assert_ne!(baseline, swapped);
+}

--- a/easy_hash_derive/src/lib.rs
+++ b/easy_hash_derive/src/lib.rs
@@ -284,6 +284,25 @@ mod tests {
     }
 
     #[test]
+    fn test_struct_with_lifetime_param() {
+        let input: DeriveInput = parse_quote! {
+            struct Example<'a> {
+                data: &'a u32,
+            }
+        };
+
+        let actual = expand_as_string(input);
+        assert!(
+            actual.contains("impl < 'a > easy_hash :: EasyHash for Example < 'a >"),
+            "expected lifetime param in impl header: {actual}"
+        );
+        assert!(
+            !actual.contains("'a : easy_hash :: EasyHash"),
+            "unexpected EasyHash bound on lifetime: {actual}"
+        );
+    }
+
+    #[test]
     fn test_enum_variants_mixed_fields() {
         let input: DeriveInput = parse_quote! {
             enum Example {
@@ -356,5 +375,17 @@ mod tests {
         .to_string();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_union_not_supported() {
+        let input: DeriveInput = parse_quote! {
+            union Example {
+                x: u32,
+            }
+        };
+
+        let _ = expand_as_string(input);
     }
 }


### PR DESCRIPTION
### Motivation
- Bring overall coverage from ~81% to 100% by adding targeted tests for remaining uncovered modules and branches. 
- Cover branchy primitives (max/edge cases), bytemuck unaligned head/tail handling, and Godot vector implementations to exercise previously-missed code paths.  
- Add proc-macro unit tests to exercise lifetime handling and the unsupported-union path, plus a small IdentityHasher panic test to cover `type_id` edge behavior.

### Description
- Added new tests in `easy_hash/tests/`: `test_godot.rs`, `test_bytemuck_alignment.rs`, `test_primitives_branches.rs`, and `test_type_salt_generic.rs` that exercise Godot vector hashing, bytemuck alignment handling, primitive max/edge branches, property-based checks and generic salt behavior. 
- Extended `easy_hash/tests/test_strings.rs` with an exact-chunk string case to cover string chunking logic. 
- Added a small test module to `easy_hash/src/type_id.rs` that asserts `IdentityHasher::write` panics as expected. 
- Extended `easy_hash_derive/src/lib.rs` tests to cover lifetime-parameterized structs and a union case (expected to panic) to ensure the derive macro handles and documents unsupported shapes. 
- Used `proptest` for two property-style tests that exercise wide value spaces for `u64` and `i64` hashing invariants, and `test-case` for parameterized non-max value checks. 
- Ran `cargo fmt` on modified files.

### Testing
- Ran the full test suite with `cargo test` and confirmed all tests passed (including the new unit, parameterized and `proptest` cases). 
- Measured coverage with `cargo llvm-cov --workspace --summary-only` and verified coverage reached `100.00%` for the workspace. 
- Formatting enforced via `cargo fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69692138dd388323afd0001707176690)